### PR TITLE
Dockerize build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,8 @@ RUN micromamba install -y -n base -f /src/conda_environment_docker.yaml && \
 ARG MAMBA_DOCKERFILE_ACTIVATE=1  
 
 # Install python dependencies
-RUN pip install mani_skill2
+RUN pip install -r  docker_pip_requirements.txt mani_skill2
 
 # Copy over all source code
 WORKDIR /src/
 COPY . /src/
-
-# Set environment for RL
-ENV ENV_ID PickSingleEGAD-v0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# By default, we build without Cuda drivers
+FROM mambaorg/micromamba:1.4.2-focal
+
+# Use instead the following line to build with Cuda drivers
+# (should only be used if intending to run Docker image on system
+# with Nvidia GPUs)
+#FROM mambaorg/micromamba:git-3208378-focal-cuda-11.6.2
+
+# See https://github.com/mamba-org/micromamba-docker#quick-start
+# for details on using Micromamba in Docker
+
+USER root
+RUN apt-get update && apt-get install -y libosmesa6-dev libgl1-mesa-glx libglfw3 patchelf
+
+USER $MAMBA_USER
+
+RUN mkdir src 
+COPY --chown=$MAMBA_USER:$MAMBA_USER conda_environment_docker.yaml /src/conda_environment_docker.yaml
+RUN micromamba install -y -n base -f /src/conda_environment_docker.yaml && \
+  micromamba clean --all --yes
+
+# Activate mamba environment
+ARG MAMBA_DOCKERFILE_ACTIVATE=1  
+
+# Install python dependencies
+RUN pip install mani_skill2
+
+# Copy over all source code
+WORKDIR /src/
+COPY . /src/
+
+# Set environment for RL
+ENV ENV_ID PickSingleEGAD-v0

--- a/README_BC.md
+++ b/README_BC.md
@@ -28,3 +28,34 @@ Download training data:
 ```console
 [data]$ python -m mani_skill2.utils.download_demo all  
 ```
+
+## Running in Docker
+The docker image can be built either with or without Cuda drivers. By default, it is built without, to be able to run on devices without NVidia GPUs. To enable cuda, see the Dockerfile for details.
+
+To build the Docker image, run
+```console
+docker build . --tag diffusion --platform linux/amd64
+```
+(this will probably take ~10 minutes the first time).
+
+Next, we want to run the Docker file, and mount our local data folder so that the Docker image can create and manipulate the data folder.
+First, navigate to this repo on your local system, and make sure to create a folder for data:
+```console
+mkdir -p data/demos
+```
+Next, let us run the docker image in interactive mode, while mounting our `data` folder as a volume in the image:
+```console
+docker run --platform linux/amd64 -v $PWD/data:/src/data/ -it diffusion 
+```
+(now, the Docker image will be able to save data between runs to `data`)
+
+You should now be able to run code in the interactive Docker shell. For instance, try downloading the demo and asset data for the current environment `ENV_ID` (change by setting i.e. `export ENV_ID="PickSingleEGAD-v0"`):
+```
+python -m mani_skill2.utils.download_demo ${ENV_ID} -o data/demos
+python -m mani_skill2.utils.download_asset ${ENV_ID} -o data
+```
+
+In theory, it should also work to replay trajectories through Docker. However, currently, the following seems to be very slow
+```
+python -m mani_skill2.trajectory.replay_trajectory --traj-path data/demos/rigid_body/${ENV_ID}/trajectory.h5 --save-traj --obs-mode state --target-control-mode pd_ee_delta_pose
+```

--- a/conda_environment_docker.yaml
+++ b/conda_environment_docker.yaml
@@ -1,0 +1,64 @@
+name: robodiff
+channels:
+  - pytorch
+  - pytorch3d
+  - nvidia
+  - conda-forge
+dependencies:
+  - python=3.9
+  - pip=22.2.2
+  - cudatoolkit=11.6
+  - pytorch=1.12.1
+  - torchvision=0.13.1
+  - pytorch3d=0.7.0
+  - numpy=1.23.3
+  - numba==0.56.4
+  - scipy==1.9.1
+  - py-opencv=4.6.0
+  - cffi=1.15.1
+  - ipykernel=6.16
+  - matplotlib=3.6.1
+  - zarr=2.12.0
+  - numcodecs=0.10.2
+  - h5py=3.7.0
+  - hydra-core=1.2.0
+  - einops=0.4.1
+  - tqdm=4.64.1
+  - dill=0.3.5.1
+  - scikit-video=1.1.11
+  - scikit-image=0.19.3
+  - gym=0.21.0
+  - pymunk=6.2.1
+  - wandb=0.13.3
+  - threadpoolctl=3.1.0
+  - shapely=1.8.4
+  - cython=0.29.32
+  - imageio=2.22.0
+  - imageio-ffmpeg=0.4.7
+  - termcolor=2.0.1
+  - tensorboard=2.10.1
+  - tensorboardx=2.5.1
+  - psutil=5.9.2
+  - click=8.0.4
+  - boto3=1.24.96
+  - accelerate=0.13.2
+  - datasets=2.6.1
+  - diffusers=0.11.1
+  - av=10.0.0
+  - cmake=3.24.3
+  # trick to force reinstall imagecodecs via pip
+  - imagecodecs==2022.8.8
+  # - pip:
+  #   - ray[default,tune]==2.2.0
+  #   # requires mujoco py dependencies libosmesa6-dev libgl1-mesa-glx libglfw3 patchelf
+  #   - free-mujoco-py==2.1.6
+  #   - pygame==2.1.2
+  #   # - pybullet-svl==3.1.6.4
+  #   - robosuite @ https://github.com/cheng-chi/robosuite/archive/277ab9588ad7a4f4b55cf75508b44aa67ec171f0.tar.gz
+  #   - robomimic==0.2.0
+  #   - pytorchvideo==0.1.5
+  #   # pip package required for jpeg-xl
+  #   - imagecodecs==2022.9.26
+  #   - r3m @ https://github.com/facebookresearch/r3m/archive/b2334e726887fa0206962d7984c69c5fb09cceab.tar.gz
+  #   - dm-control==1.0.9
+  #   - mani-skill2==0.4.2

--- a/conda_environment_docker.yaml
+++ b/conda_environment_docker.yaml
@@ -48,17 +48,3 @@ dependencies:
   - cmake=3.24.3
   # trick to force reinstall imagecodecs via pip
   - imagecodecs==2022.8.8
-  # - pip:
-  #   - ray[default,tune]==2.2.0
-  #   # requires mujoco py dependencies libosmesa6-dev libgl1-mesa-glx libglfw3 patchelf
-  #   - free-mujoco-py==2.1.6
-  #   - pygame==2.1.2
-  #   # - pybullet-svl==3.1.6.4
-  #   - robosuite @ https://github.com/cheng-chi/robosuite/archive/277ab9588ad7a4f4b55cf75508b44aa67ec171f0.tar.gz
-  #   - robomimic==0.2.0
-  #   - pytorchvideo==0.1.5
-  #   # pip package required for jpeg-xl
-  #   - imagecodecs==2022.9.26
-  #   - r3m @ https://github.com/facebookresearch/r3m/archive/b2334e726887fa0206962d7984c69c5fb09cceab.tar.gz
-  #   - dm-control==1.0.9
-  #   - mani-skill2==0.4.2

--- a/docker_pip_requirements.txt
+++ b/docker_pip_requirements.txt
@@ -1,0 +1,10 @@
+ray[default,tune]==2.2.0
+free-mujoco-py==2.1.6
+pygame==2.1.2
+robosuite @ https://github.com/cheng-chi/robosuite/archive/277ab9588ad7a4f4b55cf75508b44aa67ec171f0.tar.gz
+robomimic==0.2.0
+pytorchvideo==0.1.5
+imagecodecs==2022.9.26
+r3m @ https://github.com/facebookresearch/r3m/archive/b2334e726887fa0206962d7984c69c5fb09cceab.tar.gz
+dm-control==1.0.9
+mani-skill2==0.4.2


### PR DESCRIPTION
Adds a Dockerfile for the project.

See the Docker section of [README_BC.md](https://github.com/wrangelvid/diffusion-policy-dev/blob/dockerize/README_BC.md) for details.

**NOTE:** Installs all requirements for the project into a docker container, except for python dependencies (for some reason, these would not be built with conda). Maniskill is the only python dependency that is added to the docker image currently; The reason for this is that this is what I was currently using. To run the full training pipeline, the remaining packages from the `pip` section of  `environment_conda_docker.py` (commented out) must likely be installed. I suggest to merge this in to the repo nonetheless, so that people can utilize the Dockerfile if they need it short-term, and they can add in the python packages as needed when they need them. Currently, I have only used this to investigate the data structure for rgbd/image policies (which is why I haven't focused on added in the remaining packages yet).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wrangelvid/diffusion-policy-dev/4)
<!-- Reviewable:end -->
